### PR TITLE
generate_zar.py fixes

### DIFF
--- a/generate_data/generate_z5py.py
+++ b/generate_data/generate_z5py.py
@@ -12,7 +12,7 @@ COMPRESSION_OPTIONS = {"blosc": {"codec": "lz4"}}
 # - more compressors in numcodecs
 # - more blosc codecs
 def generate_zarr_format(compressors=['gzip', 'blosc', 'zlib', 'raw']):
-    path = '../data/z5py.zr'
+    path = 'data/z5py.zr'
     im = astronaut()
 
     f = z5py.File(path)
@@ -27,7 +27,7 @@ def generate_zarr_format(compressors=['gzip', 'blosc', 'zlib', 'raw']):
 
 
 def generate_n5_format(compressors=['gzip', 'raw']):
-    path = '../data/z5py.n5'
+    path = 'data/z5py.n5'
     im = astronaut()
 
     f = z5py.File(path)

--- a/generate_data/generate_zarr.py
+++ b/generate_data/generate_zarr.py
@@ -14,7 +14,7 @@ COMPRESSION_OPTIONS = {"blosc": {"cname": "lz4"}}
 
 # TODO use more compressors from numcodecs and more blosc filter_ids
 def generate_zarr_format(compressors=['gzip', 'blosc', 'zlib', None]):
-    path = '../data/zarr.zr'
+    path = 'data/zarr.zr'
     im = astronaut()
 
     f = zarr.open(path)
@@ -33,7 +33,7 @@ def generate_zarr_format(compressors=['gzip', 'blosc', 'zlib', None]):
 
 # this needs PR https://github.com/zarr-developers/zarr/pull/309
 def generate_n5_format(compressors=['gzip', None]):
-    path = '../data/zarr.n5'
+    path = 'data/zarr.n5'
     im = astronaut()
 
     f = zarr.open(path)

--- a/generate_data/generate_zarr.py
+++ b/generate_data/generate_zarr.py
@@ -9,7 +9,7 @@ STR_TO_COMPRESSOR = {
     "blosc": numcodecs.Blosc,
     "zlib": numcodecs.Zlib,
 }
-COMPRESSION_OPTIONS = {"blosc": {"codec": "lz4"}}
+COMPRESSION_OPTIONS = {"blosc": {"cname": "lz4"}}
 
 
 # TODO use more compressors from numcodecs and more blosc filter_ids
@@ -21,9 +21,9 @@ def generate_zarr_format(compressors=['gzip', 'blosc', 'zlib', None]):
     for compressor in compressors:
         copts = COMPRESSION_OPTIONS.get(compressor, {})
         if compressor is None:
-            name = "taw"
+            name = "raw"
         elif compressor == "blosc":
-            name = "%s/%s" % (compressor, copts.get("codec"))
+            name = "%s/%s" % (compressor, copts.get("cname"))
         else:
             name = compressor
         compressor_impl = STR_TO_COMPRESSOR[compressor](**copts) if compressor is not None else None
@@ -39,7 +39,7 @@ def generate_n5_format(compressors=['gzip', None]):
     f = zarr.open(path)
     for compressor in compressors:
         name = compressor if compressor is not None else 'raw'
-        compressor_impl = STR_TO_COMPRESSOR[compressor] if compressor is not None else None
+        compressor_impl = STR_TO_COMPRESSOR[compressor]() if compressor is not None else None
         f.create_dataset(name, data=im, chunks=CHUNKS,
                          compressor=compressor_impl)
 

--- a/test/test_read_all.py
+++ b/test/test_read_all.py
@@ -40,6 +40,8 @@ READABLE_CODECS: Dict[str, Dict[str, List[str]]] = {
 
 def read_with_zarr(fpath, ds_name):
     import zarr
+    if ds_name == "blosc":
+        ds_name = "blosc/lz4"
     return zarr.open(os.fspath(fpath))[ds_name][:]
 
 
@@ -50,6 +52,8 @@ def read_with_pyn5(fpath, ds_name):
 
 def read_with_z5py(fpath, ds_name):
     import z5py
+    if ds_name == "blosc":
+        ds_name = "blosc/lz4"
     return z5py.File(fpath)[ds_name][:]
 
 


### PR DESCRIPTION
cc: @Carreau @constantinpape

This is allowing me to generate the files though I am still getting a test failure:

```
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

s = array([123,  34,  99, 111, 109, 112, 114, 101, 115, 115, 105, 111, 110,
        34,  58, 123,  34, 116, 121, 112, 101,...10, 115, 105, 111, 110, 115,  34,  58,  91,  51,  44,  53,
        49,  50,  44,  53,  49,  50,  93, 125], dtype=uint8)
encoding = 'ascii'

    def ensure_text(s, encoding='utf-8'):
        if not isinstance(s, str):
            s = ensure_contiguous_ndarray(s)
>           s = codecs.decode(s, encoding)
E           UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 31: ordinal not in range(128)

/opt/conda/envs/z/lib/python3.7/site-packages/numcodecs/compat.py:129: UnicodeDecodeError
=============================== warnings summary ===============================
test/test_read_all.py::test_correct_read[N5-bzip2-from-pyn5-with-pyn5]
test/test_read_all.py::test_correct_read[N5-gzip-from-pyn5-with-pyn5]
test/test_read_all.py::test_correct_read[N5-raw-from-pyn5-with-pyn5]
  /opt/conda/envs/z/lib/python3.7/site-packages/pyn5/file_group.py:228: UserWarning: Expected N5 version '2.0.2', got 2.1.3; trying to open anyway
    warnings.warn(f"Expected N5 version '{N5_VERSION}', got {version};"

-- Docs: https://docs.pytest.org/en/stable/warnings.html
=========================== short test summary info ============================
FAILED test/test_read_all.py::test_correct_read[N5-gzip-from-n5-java-with-zarr]
FAILED test/test_read_all.py::test_correct_read[N5-raw-from-n5-java-with-zarr]
=================== 2 failed, 12 passed, 3 warnings in 1.22s ===================
```