### PR TITLE
Truncate files when generating test data

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ dependencies:
   - openjdk
   - maven
   - make
-  - z5py
+  - z5py >= 2.0.8
   - python == 3.7.9
   - scikit-image
   - pytest

--- a/generate_data/generate_z5py.py
+++ b/generate_data/generate_z5py.py
@@ -15,7 +15,7 @@ def generate_zarr_format(compressors=['gzip', 'blosc', 'zlib', 'raw']):
     path = 'data/z5py.zr'
     im = astronaut()
 
-    f = z5py.File(path)
+    f = z5py.File(path, mode='w')
     for compressor in compressors:
         copts = COMPRESSION_OPTIONS.get(compressor, {})
         name = (
@@ -30,7 +30,7 @@ def generate_n5_format(compressors=['gzip', 'raw']):
     path = 'data/z5py.n5'
     im = astronaut()
 
-    f = z5py.File(path)
+    f = z5py.File(path, mode='w')
     for compressor in compressors:
         name = compressor
         f.create_dataset(name, data=im, chunks=CHUNKS, compression=compressor)

--- a/generate_data/generate_zarr.py
+++ b/generate_data/generate_zarr.py
@@ -17,7 +17,7 @@ def generate_zarr_format(compressors=['gzip', 'blosc', 'zlib', None]):
     path = 'data/zarr.zr'
     im = astronaut()
 
-    f = zarr.open(path)
+    f = zarr.open(path, mode='w')
     for compressor in compressors:
         copts = COMPRESSION_OPTIONS.get(compressor, {})
         if compressor is None:
@@ -31,12 +31,11 @@ def generate_zarr_format(compressors=['gzip', 'blosc', 'zlib', None]):
                          compressor=compressor_impl)
 
 
-# this needs PR https://github.com/zarr-developers/zarr/pull/309
 def generate_n5_format(compressors=['gzip', None]):
     path = 'data/zarr.n5'
     im = astronaut()
 
-    f = zarr.open(path)
+    f = zarr.open(path, mode='w')
     for compressor in compressors:
         name = compressor if compressor is not None else 'raw'
         compressor_impl = STR_TO_COMPRESSOR[compressor]() if compressor is not None else None


### PR DESCRIPTION
Hi @Carreau,

I looked into this and the test failure was caused by not truncating the files in `generate_z5py`.
I fixed it (and also added a truncate in `generate_zarr`).

Note that there will probably still be a test failure because `z5py` can't read n5 files generated by `zarr`.
I finally figured out that this is because zarr not truncating overhanging chunks; I am trying to fix this in z5py now. 